### PR TITLE
Adding bootRun task to quarkus version

### DIFF
--- a/build-quarkus.gradle
+++ b/build-quarkus.gradle
@@ -42,3 +42,5 @@ quarkusBuild {
 		buildImage = "quay.io/quarkus/ubi-quarkus-native-image:20.2.0-java11"
 	}
 }
+
+task bootRun(dependsOn: 'quarkusDev')


### PR DESCRIPTION
`build-quarkus.gradle` now exposes a `bootRun` task